### PR TITLE
IDENTITY-6364: removing filter mapping for AuthorizationHeaderFilter 

### DIFF
--- a/components/org.wso2.carbon.identity.scim.provider/src/main/webapp/WEB-INF/web.xml
+++ b/components/org.wso2.carbon.identity.scim.provider/src/main/webapp/WEB-INF/web.xml
@@ -37,16 +37,6 @@
         <url-pattern>*</url-pattern>
     </filter-mapping>
 
-    <filter>
-        <filter-name>AuthorizationHeaderFilter</filter-name>
-        <filter-class>org.wso2.carbon.identity.core.filter.AuthorizationHeaderFilter</filter-class>
-    </filter>
-
-    <filter-mapping>
-        <filter-name>AuthorizationHeaderFilter</filter-name>
-        <url-pattern>/*</url-pattern>
-    </filter-mapping>
-
     <servlet>
         <servlet-name>SCIMServlet</servlet-name>
         <display-name>SCIMServlet</display-name>


### PR DESCRIPTION
Removing the filter mappings at web app level since we are going to engage it globally via tomcat web.xml file