### PR TITLE
Integrate Jacoco plugin to calculate unit tests coverage

### DIFF
--- a/components/org.wso2.carbon.identity.scim.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim.common/pom.xml
@@ -152,19 +152,28 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
 	        <executions>
 		    <execution>
-		        <id>default-check-by-coverage-enforcer</id>
-		        <configuration>
-			    <rules>
-			        <rule implementation="org.jacoco.maven.RuleConfiguration"> 
-				    <limits>
-				        <limit implementation="org.jacoco.report.check.Limit">
-					    <minimum>0.0</minimum>
-				        </limit>
-				    </limits>
-			        </rule>
-			    </rules>
-		        </configuration>
-		    </execution>
+			    <id>default-check-by-coverage-enforcer</id>
+			    <goals>
+			        <goal>check</goal>
+			    </goals>
+			    <configuration>
+			        <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+			        <rules>
+				    <!-- implementation is needed only for Maven 2 -->
+				    <rule implementation="org.jacoco.maven.RuleConfiguration">
+				        <element>BUNDLE</element>
+				        <limits>
+					    <!-- implementation is needed only for Maven 2 -->
+					    <limit implementation="org.jacoco.report.check.Limit">
+					        <counter>LINE</counter>
+					        <value>COVEREDRATIO</value>
+					        <minimum>0.0</minimum>
+					    </limit>
+				        </limits>
+				    </rule>
+			        </rules>
+			    </configuration>
+		        </execution>
 		</executions>
             </plugin>
             <plugin>

--- a/components/org.wso2.carbon.identity.scim.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim.common/pom.xml
@@ -150,6 +150,31 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+	        <executions>
+		    <execution>
+		        <id>default-check-by-coverage-enforcer</id>
+		        <goals>
+			    <goal>check</goal>
+		        </goals>
+		        <configuration>
+			    <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+			    <rules>
+			        <!-- implementation is needed only for Maven 2 -->
+			        <rule implementation="org.jacoco.maven.RuleConfiguration">
+				    <element>BUNDLE</element>
+				    <limits>
+				        <!-- implementation is needed only for Maven 2 -->
+				        <limit implementation="org.jacoco.report.check.Limit">
+					    <counter>LINE</counter>
+					    <value>COVEREDRATIO</value>
+					    <minimum>0.0</minimum>
+				        </limit>
+				    </limits>
+			        </rule>
+			    </rules>
+		        </configuration>
+		    </execution>
+		</executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/components/org.wso2.carbon.identity.scim.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim.common/pom.xml
@@ -153,20 +153,11 @@
 	        <executions>
 		    <execution>
 		        <id>default-check-by-coverage-enforcer</id>
-		        <goals>
-			    <goal>check</goal>
-		        </goals>
 		        <configuration>
-			    <dataFile>${project.build.directory}/jacoco.exec</dataFile>
 			    <rules>
-			        <!-- implementation is needed only for Maven 2 -->
-			        <rule implementation="org.jacoco.maven.RuleConfiguration">
-				    <element>BUNDLE</element>
+			        <rule implementation="org.jacoco.maven.RuleConfiguration"> 
 				    <limits>
-				        <!-- implementation is needed only for Maven 2 -->
 				        <limit implementation="org.jacoco.report.check.Limit">
-					    <counter>LINE</counter>
-					    <value>COVEREDRATIO</value>
 					    <minimum>0.0</minimum>
 				        </limit>
 				    </limits>

--- a/components/org.wso2.carbon.identity.scim.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim.common/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
  ~ Copyright (c) 2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  ~
  ~ WSO2 Inc. licenses this file to you under the Apache License,
@@ -14,21 +13,17 @@
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim</groupId>
         <artifactId>identity-inbound-provisioning-scim</artifactId>
         <relativePath>../../pom.xml</relativePath>
         <version>5.3.23-SNAPSHOT</version>
     </parent>
-
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.identity.scim.common</artifactId>
     <name>WSO2 Carbon - SCIM - Common Component</name>
     <packaging>bundle</packaging>
-
     <dependencies>
         <dependency>
             <groupId>commons-collections.wso2</groupId>
@@ -86,7 +81,6 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -101,7 +95,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-scr-plugin</artifactId>
-
                 <executions>
                     <execution>
                         <id>generate-scr-scrdescriptor</id>
@@ -154,7 +147,14 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,8 @@
         <axis2.osgi.version.range>[1.6.1.wso2v12, 2.0.0)</axis2.osgi.version.range>
         <scim.common.imp.pkg.version.range>[5.0.0, 6.0.0)</scim.common.imp.pkg.version.range>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
+	<jacoco.maven.plugin.version>0.8.0</jacoco.maven.plugin.version>
+	<maven.surefire.plugin.version>2.21.0</maven.surefire.plugin.version>
     </properties>
     <build>
         <pluginManagement>
@@ -307,7 +309,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.0</version>
+                    <version>${jacoco.maven.plugin.version}</version>
                     <executions>
                         <execution>
                             <id>default-prepare-agent-by-coverage-enforcer</id>
@@ -328,35 +330,12 @@
                                 <dataFile>${project.build.directory}/jacoco.exec</dataFile>
                             </configuration>
                         </execution>
-                        <execution>
-                            <id>default-check-by-coverage-enforcer</id>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                            <configuration>
-                                <dataFile>${project.build.directory}/jacoco.exec</dataFile>
-                                <rules>
-                                    <!-- implementation is needed only for Maven 2 -->
-                                    <rule implementation="org.jacoco.maven.RuleConfiguration">
-                                        <element>BUNDLE</element>
-                                        <limits>
-                                            <!-- implementation is needed only for Maven 2 -->
-                                            <limit implementation="org.jacoco.report.check.Limit">
-                                                <counter>LINE</counter>
-                                                <value>COVEREDRATIO</value>
-                                                <minimum>0.0</minimum>
-                                            </limit>
-                                        </limits>
-                                    </rule>
-                                </rules>
-                            </configuration>
-                        </execution>
                     </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.21.0</version>
+                    <version>${maven.surefire.plugin.version}</version>
                     <configuration>
                         <argLine>${argLine}</argLine>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
@@ -15,26 +14,20 @@
   ~ KIND, either express or implied.  See the License for the
   ~ specific language governing permissions and limitations
   ~ under the License.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.wso2</groupId>
         <artifactId>wso2</artifactId>
         <version>1</version>
     </parent>
-
     <groupId>org.wso2.carbon.identity.inbound.provisioning.scim</groupId>
     <artifactId>identity-inbound-provisioning-scim</artifactId>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>
     <version>5.3.23-SNAPSHOT</version>
     <name>WSO2 Carbon - SCIM Provisioning Module</name>
-    <description>
-
-    </description>
+    <description/>
     <url>http://wso2.org</url>
-
     <scm>
         <url>https://github.com/wso2-extensions/identity-inbound-provisioning-scim.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-inbound-provisioning-scim.git
@@ -42,7 +35,6 @@
         <connection>scm:git:https://github.com/wso2-extensions/identity-inbound-provisioning-scim.git</connection>
         <tag>HEAD</tag>
     </scm>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -167,7 +159,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <repositories>
         <repository>
             <id>wso2-nexus</id>
@@ -179,7 +170,6 @@
                 <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </repository>
-
         <repository>
             <id>wso2.releases</id>
             <name>WSO2 internal Repository</name>
@@ -190,7 +180,6 @@
                 <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </repository>
-
         <repository>
             <id>wso2.snapshots</id>
             <name>Apache Snapshot Repository</name>
@@ -203,9 +192,7 @@
                 <enabled>false</enabled>
             </releases>
         </repository>
-
     </repositories>
-
     <pluginRepositories>
         <pluginRepository>
             <id>wso2.releases</id>
@@ -217,7 +204,6 @@
                 <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </pluginRepository>
-
         <pluginRepository>
             <id>wso2.snapshots</id>
             <name>WSO2 Snapshot Repository</name>
@@ -241,19 +227,16 @@
             </releases>
         </pluginRepository>
     </pluginRepositories>
-
     <modules>
         <module>components/org.wso2.carbon.identity.scim.common</module>
         <module>components/org.wso2.carbon.identity.scim.provider</module>
         <module>components/org.wso2.carbon.identity.scim.ui</module>
         <module>components/org.wso2.carbon.identity.scim.common.stub</module>
-
         <module>features/org.wso2.carbon.identity.scim.common.feature</module>
         <module>features/org.wso2.carbon.identity.scim.feature</module>
         <module>features/org.wso2.carbon.identity.scim.provider.feature</module>
         <module>features/org.wso2.carbon.identity.scim.ui.feature</module>
     </modules>
-
     <properties>
         <charon.wso2.version.identity>2.1.3</charon.wso2.version.identity>
         <charon.core.imp.pkg.version.range>[2.0.1,3.0.0)</charon.core.imp.pkg.version.range>
@@ -263,20 +246,15 @@
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.4.7</carbon.kernel.version>
         <junit.version>4.11</junit.version>
-
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
         <maven.scr.plugin.version>1.16.0</maven.scr.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
-
         <!-- Axis2 Version -->
         <axis2.wso2.version>1.6.1.wso2v12</axis2.wso2.version>
-
         <axiom.wso2.version>1.2.11.wso2v10</axiom.wso2.version>
-
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-
         <identity.framework.version>5.10.52</identity.framework.version>
         <identity.inbound.provisioning.scim.export.version>${project.version}
         </identity.inbound.provisioning.scim.export.version>
@@ -293,11 +271,9 @@
         <scim.common.imp.pkg.version.range>[5.0.0, 6.0.0)</scim.common.imp.pkg.version.range>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
     </properties>
-
     <build>
         <pluginManagement>
             <plugins>
-
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
@@ -328,9 +304,65 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.0</version>
+                    <executions>
+                        <execution>
+                            <id>default-prepare-agent-by-coverage-enforcer</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                            <configuration>
+                                <propertyName>argLine</propertyName>
+                                <destFile>${project.build.directory}/jacoco.exec</destFile>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>default-report-by-coverage-enforcer</id>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                            <configuration>
+                                <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>default-check-by-coverage-enforcer</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                                <rules>
+                                    <!-- implementation is needed only for Maven 2 -->
+                                    <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                        <element>BUNDLE</element>
+                                        <limits>
+                                            <!-- implementation is needed only for Maven 2 -->
+                                            <limit implementation="org.jacoco.report.check.Limit">
+                                                <counter>COMPLEXITY</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>0.0</minimum>
+                                            </limit>
+                                        </limits>
+                                    </rule>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.21.0</version>
+                    <configuration>
+                        <argLine>${argLine}</argLine>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -361,5 +393,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,30 @@
                                 <dataFile>${project.build.directory}/jacoco.exec</dataFile>
                             </configuration>
                         </execution>
-                    </executions>
+		        <execution>
+			    <id>default-check-by-coverage-enforcer</id>
+			    <goals>
+			        <goal>check</goal>
+			    </goals>
+			    <configuration>
+			        <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+			        <rules>
+				    <!-- implementation is needed only for Maven 2 -->
+				    <rule implementation="org.jacoco.maven.RuleConfiguration">
+				        <element>BUNDLE</element>
+				        <limits>
+					    <!-- implementation is needed only for Maven 2 -->
+					    <limit implementation="org.jacoco.report.check.Limit">
+					        <counter>LINE</counter>
+					        <value>COVEREDRATIO</value>
+					        <minimum>0.0</minimum>
+					    </limit>
+				        </limits>
+				    </rule>
+			        </rules>
+			    </configuration>
+		        </execution>
+		    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -330,29 +330,6 @@
                                 <dataFile>${project.build.directory}/jacoco.exec</dataFile>
                             </configuration>
                         </execution>
-		        <execution>
-			    <id>default-check-by-coverage-enforcer</id>
-			    <goals>
-			        <goal>check</goal>
-			    </goals>
-			    <configuration>
-			        <dataFile>${project.build.directory}/jacoco.exec</dataFile>
-			        <rules>
-				    <!-- implementation is needed only for Maven 2 -->
-				    <rule implementation="org.jacoco.maven.RuleConfiguration">
-				        <element>BUNDLE</element>
-				        <limits>
-					    <!-- implementation is needed only for Maven 2 -->
-					    <limit implementation="org.jacoco.report.check.Limit">
-					        <counter>LINE</counter>
-					        <value>COVEREDRATIO</value>
-					        <minimum>0.0</minimum>
-					    </limit>
-				        </limits>
-				    </rule>
-			        </rules>
-			    </configuration>
-		        </execution>
 		    </executions>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
                                         <limits>
                                             <!-- implementation is needed only for Maven 2 -->
                                             <limit implementation="org.jacoco.report.check.Limit">
-                                                <counter>COMPLEXITY</counter>
+                                                <counter>LINE</counter>
                                                 <value>COVEREDRATIO</value>
                                                 <minimum>0.0</minimum>
                                             </limit>


### PR DESCRIPTION
## Purpose
Generate unit test coverage information

## Goals
Invoking Jacoco Maven plugin to generate coverage report for 'components/org.wso2.carbon.identity.scim.common'

## Approach
* Adding Jacoco Maven plugin in the parent pom and inheriting it in the  'components/org.wso2.carbon.identity.scim.common' module's pom file
* Adding Maven Surefire plugin and configure it to pick up Jacoco plugin's agent

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A