### PR TITLE
Fixing issue of scim/me endpoint doesn't return wso2extension section

### DIFF
--- a/components/org.wso2.carbon.identity.scim.provider/src/main/java/org/wso2/carbon/identity/scim/provider/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim.provider/src/main/java/org/wso2/carbon/identity/scim/provider/impl/SCIMUserManager.java
@@ -396,7 +396,17 @@ public class SCIMUserManager implements UserManager {
                         continue;
                     }
 
-                    scimUser = this.getSCIMUserWithoutRoles(userName, new ArrayList<String>());
+                    List<String> claimURIList = new ArrayList<>();
+                    if (Boolean.parseBoolean(IdentityUtil.getProperty(SCIMProviderConstants
+                            .ELEMENT_NAME_SHOW_ALL_USER_DETAILS))) {
+                        // Get claims related to SCIM claim dialect.
+                        ClaimMapping[] claims = carbonClaimManager.
+                                getAllClaimMappings(SCIMCommonConstants.SCIM_CLAIM_DIALECT);
+                        for (ClaimMapping claim : claims) {
+                            claimURIList.add(claim.getClaim().getClaimUri());
+                        }
+                    }
+                    scimUser = this.getSCIMUserWithoutRoles(userName, claimURIList);
                     //if SCIM-ID is not present in the attributes, skip
                     if (scimUser != null && StringUtils.isBlank(scimUser.getId())) {
                         continue;

--- a/components/org.wso2.carbon.identity.scim.provider/src/main/java/org/wso2/carbon/identity/scim/provider/util/SCIMProviderConstants.java
+++ b/components/org.wso2.carbon.identity.scim.provider/src/main/java/org/wso2/carbon/identity/scim/provider/util/SCIMProviderConstants.java
@@ -52,6 +52,8 @@ public class SCIMProviderConstants {
     public static final String DISPLAY_NAME = "displayName";
     public static final String WILDCARD_ASTERISK = "*";
 
+    public static final String ELEMENT_NAME_SHOW_ALL_USER_DETAILS = "ShowAllUserDetails";
+
     private SCIMProviderConstants(){}
 
 }


### PR DESCRIPTION
### Proposed changes in this pull request
We have removed showing all the claims when calling me endpoint due to performance issues.
If the user needs to see full details, he can enable it in identity.xml file as below.


    <SCIM>
           .....
        <ShowAllUserDetails>true</ShowAllUserDetails>
          ....

    </SCIM>

Resolves https://github.com/wso2/product-is/issues/3447