### PR TITLE
Improve SCIMTenantMgtListener with disable capability

### DIFF
--- a/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/listener/SCIMTenantMgtListener.java
+++ b/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/listener/SCIMTenantMgtListener.java
@@ -25,7 +25,6 @@ import org.wso2.carbon.identity.scim.common.utils.AdminAttributeUtil;
 import org.wso2.carbon.stratos.common.exception.StratosException;
 import org.wso2.carbon.user.core.UserStoreException;
 
-
 /**
  * This is an implementation of TenantMgtListener. This is used
  * to generate SCIM attributes for tenant admin users.
@@ -36,6 +35,14 @@ public class SCIMTenantMgtListener extends AbstractIdentityTenantMgtListener {
 
     @Override
     public void onTenantInitialActivation(int tenantId) throws StratosException {
+
+        boolean isEnabled = isEnable();
+        if (!isEnabled) {
+            if (log.isDebugEnabled()) {
+                log.debug("SCIMTenantMgtListener is fired for Tenant ID : " + tenantId);
+            }
+            return;
+        }
         //Update admin user attributes.
         try {
             AdminAttributeUtil.updateAdminUser(tenantId, false);

--- a/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/listener/SCIMTenantMgtListener.java
+++ b/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/listener/SCIMTenantMgtListener.java
@@ -39,9 +39,12 @@ public class SCIMTenantMgtListener extends AbstractIdentityTenantMgtListener {
         boolean isEnabled = isEnable();
         if (!isEnabled) {
             if (log.isDebugEnabled()) {
-                log.debug("SCIMTenantMgtListener is fired for Tenant ID : " + tenantId);
+                log.debug("SCIMTenantMgtListener is disabled");
             }
             return;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("SCIMTenantMgtListener is fired for Tenant ID : " + tenantId);
         }
         //Update admin user attributes.
         try {


### PR DESCRIPTION
## Proposed Changes
In the current implementation of the SCIMTenantMgtListener, we cannot disable the handler using configurations. With the improvement in this PR, the product admins can disable the lister if needed.