### PR TITLE
Fix immutable status of groups claim

### DIFF
--- a/components/org.wso2.carbon.identity.scim.provider/src/main/java/org/wso2/carbon/identity/scim/provider/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim.provider/src/main/java/org/wso2/carbon/identity/scim/provider/impl/SCIMUserManager.java
@@ -1893,8 +1893,8 @@ public class SCIMUserManager implements UserManager {
                 .USER_NAME_URI)) || claim.equals(claimMappings.get(SCIMConstants.ROLES_URI)) || claim.equals
                 (claimMappings.get(SCIMConstants.META_CREATED_URI)) || claim.equals(claimMappings.get(SCIMConstants
                 .META_LAST_MODIFIED_URI)) || claim.equals(claimMappings.get(SCIMConstants.META_LOCATION_URI)) ||
-                claim.equals(claimMappings.get(SCIMConstants.NAME_FAMILY_NAME_URI)) || claim.contains
-                (UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI);
+                claim.equals(claimMappings.get(SCIMConstants.NAME_FAMILY_NAME_URI)) || claim.equals(claimMappings
+                .get(SCIMConstants.GROUPS_URI)) || claim.contains(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI);
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/11328.

Groups is a read only attribute. Reference: https://tools.ietf.org/html/rfc7643#section-4.1.2