### PR TITLE
Add, Check SCIM:Core:1.0 listener is enabled, if then disable modification

### DIFF
--- a/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/utils/AdminAttributeUtil.java
+++ b/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/utils/AdminAttributeUtil.java
@@ -74,7 +74,8 @@ public class AdminAttributeUtil {
             );
 
             //User store level property to enable/disable SCIM
-            if ("true".equals(identityEventListenerConfig.getEnable()) && userStoreManager.isSCIMEnabled()) {
+            if (identityEventListenerConfig != null &&
+                    "true".equals(identityEventListenerConfig.getEnable()) && userStoreManager.isSCIMEnabled()) {
                 String adminUsername = ClaimsMgtUtil.getAdminUserNameFromTenantId(IdentityTenantUtil.getRealmService(),
                         tenantId);
                 //Validate for existing SCIM ID before do the update for admin user.

--- a/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/utils/AdminAttributeUtil.java
+++ b/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/utils/AdminAttributeUtil.java
@@ -23,6 +23,7 @@ package org.wso2.carbon.identity.scim.common.utils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.scim.common.group.SCIMGroupHandler;
@@ -64,20 +65,26 @@ public class AdminAttributeUtil {
                             getTenantUserRealm(tenantId).getUserStoreManager();
             if (log.isDebugEnabled()) {
                 log.debug("SCIM enable in Userstore level : " + userStoreManager.isSCIMEnabled() + ", for "
-                          + "Tenant ID : " + tenantId + ", validating for the existing SCIM ID : " + validateSCIMID);
+                        + "Tenant ID : " + tenantId + ", validating for the existing SCIM ID : " + validateSCIMID);
             }
+
+            IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty(
+                    "org.wso2.carbon.user.core.listener.UserOperationEventListener",
+                    "org.wso2.carbon.identity.scim.common.listener.SCIMUserOperationListener"
+            );
+
             //User store level property to enable/disable SCIM
-            if (userStoreManager.isSCIMEnabled()) {
+            if ("true".equals(identityEventListenerConfig.getEnable()) && userStoreManager.isSCIMEnabled()) {
                 String adminUsername = ClaimsMgtUtil.getAdminUserNameFromTenantId(IdentityTenantUtil.getRealmService(),
-                                                                                  tenantId);
+                        tenantId);
                 //Validate for existing SCIM ID before do the update for admin user.
                 if (validateSCIMID) {
                     String scimId = userStoreManager.getUserClaimValue(adminUsername, SCIMConstants.ID_URI,
-                                                                        UserCoreConstants.DEFAULT_PROFILE);
+                            UserCoreConstants.DEFAULT_PROFILE);
                     if (log.isDebugEnabled()) {
                         log.debug("Existing SCIM ID : " + scimId + " for Admin User : " + adminUsername + " in "
-                                  + "Tenant ID : " +
-                                  tenantId);
+                                + "Tenant ID : " +
+                                tenantId);
                     }
                     if (StringUtils.isEmpty(scimId)) {
                         //Generate User Attributes.

--- a/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/utils/SCIMCommonUtils.java
@@ -227,7 +227,7 @@ public class SCIMCommonUtils {
                     "org.wso2.carbon.identity.scim.common.listener.SCIMUserOperationListener"
             );
 
-            if (identityEventListenerConfig.getEnable().equals("true") && userStoreManager.isSCIMEnabled()) {
+            if ("true".equals(identityEventListenerConfig.getEnable()) && userStoreManager.isSCIMEnabled()) {
                 // Get admin user name from claim utils.
                 String adminUsername = ClaimsMgtUtil.getAdminUserNameFromTenantId(IdentityTenantUtil.getRealmService(),
                         superTenantId);

--- a/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/utils/SCIMCommonUtils.java
@@ -227,7 +227,8 @@ public class SCIMCommonUtils {
                     "org.wso2.carbon.identity.scim.common.listener.SCIMUserOperationListener"
             );
 
-            if ("true".equals(identityEventListenerConfig.getEnable()) && userStoreManager.isSCIMEnabled()) {
+            if (identityEventListenerConfig != null &&
+                    "true".equals(identityEventListenerConfig.getEnable()) && userStoreManager.isSCIMEnabled()) {
                 // Get admin user name from claim utils.
                 String adminUsername = ClaimsMgtUtil.getAdminUserNameFromTenantId(IdentityTenantUtil.getRealmService(),
                         superTenantId);

--- a/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim.common/src/main/java/org/wso2/carbon/identity/scim/common/utils/SCIMCommonUtils.java
@@ -23,13 +23,13 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.base.ServerConfiguration;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.ThreadLocalProvisioningServiceProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
-import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
-import org.wso2.carbon.base.ServerConfiguration;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.scim.common.group.SCIMGroupHandler;
@@ -39,6 +39,7 @@ import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.charon.core.schema.SCIMConstants;
 
 import java.text.SimpleDateFormat;
@@ -221,7 +222,12 @@ public class SCIMCommonUtils {
                     (UserStoreManager) SCIMCommonComponentHolder.getRealmService().
                             getTenantUserRealm(superTenantId).getUserStoreManager();
 
-            if (userStoreManager.isSCIMEnabled()) {
+            IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty(
+                    "org.wso2.carbon.user.core.listener.UserOperationEventListener",
+                    "org.wso2.carbon.identity.scim.common.listener.SCIMUserOperationListener"
+            );
+
+            if (identityEventListenerConfig.getEnable().equals("true") && userStoreManager.isSCIMEnabled()) {
                 // Get admin user name from claim utils.
                 String adminUsername = ClaimsMgtUtil.getAdminUserNameFromTenantId(IdentityTenantUtil.getRealmService(),
                         superTenantId);
@@ -240,7 +246,7 @@ public class SCIMCommonUtils {
                     claimsList.put(SCIMConstants.META_CREATED_URI, createdDate);
                     claimsList.put(SCIMConstants.META_LAST_MODIFIED_URI, createdDate);
                     userStoreManager.setUserClaimValues(adminUsername, claimsList, UserCoreConstants.DEFAULT_PROFILE);
-                    
+
                     addAdminGroup(userStoreManager);
                 }
             }


### PR DESCRIPTION
Add, Check SCIM:Core:1.0 listener is enabled, if then disable modification

### Proposed changes in this pull request

Since SCIM:1.0:User is been removed from claim-config, check SCIM:Core:1.0 listener is enabled if then disable, as follows in ``/utils/SCIMCommonUtils.java``

#### Modification 
```
             IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty(
                    "org.wso2.carbon.user.core.listener.UserOperationEventListener",
                    "org.wso2.carbon.identity.scim.common.listener.SCIMUserOperationListener"
            );

            if (identityEventListenerConfig.getEnable().equals("true") && userStoreManager.isSCIMEnabled()) {
                // Get admin user name from claim utils.
                .
                '
                '
                }
```