### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <charon.core.imp.pkg.version.range>[2.0.1,3.0.0)</charon.core.imp.pkg.version.range>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
-        <inbound.auth.oauth.version>6.2.0</inbound.auth.oauth.version>
+        <inbound.auth.oauth.version>7.0.0</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
@@ -200,7 +200,7 @@
         <axis2.wso2.version>1.6.1-wso2v38</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v16</axiom.wso2.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <identity.framework.version>5.14.67</identity.framework.version>
+        <identity.framework.version>6.0.0</identity.framework.version>
         <identity.inbound.provisioning.scim.export.version>${project.version}
         </identity.inbound.provisioning.scim.export.version>
         <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16